### PR TITLE
Set site.url and site.baseurl correctly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ author: Alexei Lozovsky
 email: a.lozovsky@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Crap I have found on the Interwebs
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: ""
+url: "https://blog.ilammy.net"
 github_username: ilammy
 
 # For the love of God, use ISO 8601


### PR DESCRIPTION
Disqus comment section from 'minima' theme requires these to be set to
proper URL of the site or else it will not generated correct absolute
URLs which are required for Disqus to work.